### PR TITLE
Supports associative array notation for objects.  Bump to 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+*egg-info
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - 3.4
+  - 3.5
 script: python -m tests.test_parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+Changelog
+=========
+
+
+1.0
+-----
+
+Changes:
+ - Permitted associative arrays to be used along with dot notation to declare objects.
+
+
+.0.4.0
+-----
+
+Changes:
+ - Allow for gaps in arrays.  An entry with None will fill the gap.
+ - Fixed bug where more than ten items would result in exception
+ - Started Changelog

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Fancy query string parsing & application/x-www-form-urlencoded parsing
 
-Copyright 2011 Adam Venturella
+Copyright 2011-2015 Adam Venturella
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,80 @@
-# Fancy Query String or application/x-www-form-urlencoded parsing
+# Query String Parsing The Way It Should Be
 
 [![Build Status](https://secure.travis-ci.org/aventurella/pyquerystring.png?branch=master)](http://travis-ci.org/aventurella/pyquerystring)
 
 ## The Problem
 
-Python's default:
+Python's default `urlparse.parse_qs()` does not understand the concept of data structures.  The standard behavior of parse_qs is as follows:
 
-```python
-	from urlparse import parse_qsl
-	from urlparse import parse_qs
+```js
+    // parse_qs("dog=lucy&dog=tucker&dog=radar&id=11")
+	{"dog": ["lucy", "tucer", "radar"], "id":[11]}
 ```
 
-does not understand the concept of data structures. When given a query string of:
+While this works for simple querystrings, anything more complex returns a less than desirable result.
 
-	&dog=lucy&dog=tucker&dog=radar&id=11
-
-*parse_qs* will return something like this:
-
-```json
-	{"dog":["lucy", "tucer", "radar"], "id":[11]}
-```
-
-This is perfect for simple things. If you wanted to communicate a more complex data structure:
-
-	&dog[0]=lucy&dog[1]=tucker&dog[2]=radar&id=11
-
-*parse_qs* will give you back something like:
-
-```json
+```js
+	// parse_qs("dog[0]=lucy&dog[1]=tucker&dog[2]=radar&id=11")
 	{"dog[0]":["lucy"], "dog[1]":["tucker"], "dog[2]":["radar"], "id":[11]}
 ```
 
-Not exactly what was described by the query string.  But that's ok, if you need fancier query strings or application/x-www-form-urlencoded parsing this library to the rescue.
+This library is intended to inteligentally parse complex querystrings that python's library is unable to handle such as the following:
+
+```
+mylist[]=item0&mylist[]=item1
+mylist[0]=item0&mylist[1]=item1
+mylist[0][0]=subitem0&mylist[0][1]=subitem1
+mylist.element=item0
+mylist.element[0]=item0&mylist.element[1]=item0
+```
 
 ## How it works
 
 Lets try some code:
 
 ```python
-	from querystring import parse
-
-	def __main__():
-		qs = "&id=foo&dog[0].name=lucy&dog[1].name=radar"
-		result = parse(qs)
-		print(result["dog"][0]["name"]) #lucy
-		print(result["dog"][1]["name"]) #radar
-
-	if __name__ == "__main__":
-		main()
+	>>> from pyquerystring import parse
+	>>> qs = "id=foo&dog[0].name=lucy&dog[1].name=radar"
+	>>> result = parse(qs)
+	>>> print(result["dog"][0]["name"])
+	lucy
+	>>> print(result)
+	{'dog': [{'name': 'lucy'}, {'name': 'radar'}], 'id': 'foo'}
 ```
-
-In other words, you get this:
-
-```json
-	{"id":"foo",
-	 "dog":[{"name":"lucy"}, {"name":"radar"}]
-	}
-```
-You can get pretty crazy with it as well.  It will handle multidimensional arrays:
-
-	&id=foo&dog[0][0]=lucy&dog[0][1]=radar&dog[1][0]=tucker&dog[1][1]=dexter
-
-even 3 dimensional arrays:
-
-	&id=foo&dog[0][0][0]=lucy&dog[0][0][1]=radar&dog[0][0][2]=tucker
-
-Or you can go totally nuts and just throw some mixed madness at it:
-
-	&id=foo&dog[2]=dexter&dog[1]=tucker&dog[0]=lucy&cat=ollie&pets[1].name=pogo&pets[1].type=catz&pets[0].name=kiki&pets[0].type=cat&fish.name=robofish&fish.type=fishz&person.name[0]=adam&person.name[1]=adamz&plants.name[0][1]=flower&plants.name[0][0]=tree&plants.name[1][0]=willow&plants.name[1][1]=fern
 
 You can also do some primitive array pushing:
 
-	&id=foo&dog[]=radar&dog[]=lucy&dog[]=tucker
-
-Or push into an object:
-
-	&id=foo&dog.name[]=radar&dog.name[]=tucker&dog.name[]=lucy
-
-And you would get:
-
-```json
-	{"id":"foo",
-    "dog":{"name":["radar", "tucker", "lucy"]}
-   }
+```python
+	>>> parse("id=foo&dog[]=radar&dog[]=lucy&dog[]=tucker")
+	{'dog': ['radar', 'lucy', 'tucker'], 'id': 'foo'}
+	>>> parse("id=foo&dog.name[]=radar&dog.name[]=tucker&dog.name[]=lucy")
+	{'dog': {'name': ['radar', 'tucker', 'lucy']}, 'id': 'foo'}
 ```
-Anyway, I think you get the idea. Crack open tests/test_parser.py if you would like to see some additional examples.
 
-P.S. You could apply this to multipart parsing as well, you would just need to extract the parts that are not files, and hand them to this query string parser.
+You can pass objects by associative array or dot notation:
+
+```python
+	>>> parse("dog[name]=radar")
+	{'dog': {'name': 'radar'}}
+	>>> parse("dog.name=radar")
+	{'dog': {'name': 'radar'}}
+```
+
+You can get pretty crazy with it as well.  It will handle multidimensional arrays:
+
+```python
+	>>> parse("id=foo&dog[0][0]=lucy&dog[0][1]=radar&dog[1][0]=tucker&dog[1][1]=dexter")
+	{'dog': [['lucy', 'radar'], ['tucker', 'dexter']], 'id': 'foo'}
+```
+
+Or you can go totally nuts and just throw some mixed madness at it:
+
+```python
+	>>> parse("id=foo&dog[1]=tucker&dog[0]=lucy&pets[1].name=pogo&pets[1].type=catz&pets[0].name=kiki&pets[0].type=cat&fish.name=robofish&fish.type=fishz&person.name[0]=adam&person.name[1]=adamz&plants.name[0][1]=flower&plants.name[0][0]=tree&plants.name[1][0]=willow&plants.name[1][1]=fern")
+	{'plants': {'name': [['tree', 'flower'], ['willow', 'fern']]}, 'fish': {'type': 'fishz', 'name': 'robofish'}, 'dog': ['lucy', 'tucker'], 'person': {'name': ['adam', 'adamz']}, 'pets': [{'type': 'cat', 'name': 'kiki'}, {'type': 'catz', 'name': 'pogo'}], 'id': 'foo'}
+```
+
+
+
+
+For more examples, crack open tests/test_parser.py to see some additional examples.

--- a/pyquerystring/__init__.py
+++ b/pyquerystring/__init__.py
@@ -1,6 +1,6 @@
 # Fancy query string parsing & application/x-www-form-urlencoded parsing
 #
-# Copyright 2013 Adam Venturella
+# Copyright 2011-2015 Adam Venturella
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 __title__ = 'pyquerystring'
-__version__ = '0.3.0'
+__version__ = '1.0.0'
 __author__ = 'Adam Venturella'
 __license__ = 'Apache 2'
-__copyright__ = 'Copyright 2013 Adam Venturella'
+__copyright__ = 'Copyright 2011-2015 Adam Venturella'
 
 from .querystring import parse
 from .querystring import QueryStringParser

--- a/pyquerystring/compat.py
+++ b/pyquerystring/compat.py
@@ -13,5 +13,7 @@ is_py3 = (_ver[0] == 3)
 
 if is_py2:
     from urlparse import parse_qsl
+    from itertools import izip_longest as zip_longest
 elif is_py3:
     from urllib.parse import parse_qsl
+    from itertools import zip_longest

--- a/pyquerystring/querystring.py
+++ b/pyquerystring/querystring.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from itertools import izip_longest
+
 from .compat import parse_qsl
 from .compat import is_py3
 
@@ -128,25 +130,39 @@ class QueryStringParser(object):
                         return
 
     def tokens(self, key):
+        """
+        Returns an iterator of the array elements (tokens) of a given key
+        """
         buf = ""
-        for char in key:
-            if char == "[":
+
+        # remove white space from any keys
+        key = key.replace(" ", "")
+
+        # Creates iterator of next chars
+        char_groups = izip_longest(key, key[1:], fillvalue=" ")
+        prev_char = " "
+        for char, next_char in char_groups:
+            if char == "[" and not next_char.isalpha():
                 yield QueryStringToken.ARRAY, buf
                 buf = ""
 
-            elif char == ".":
+            elif char == "[" or char == ".":
                 yield QueryStringToken.OBJECT, buf
                 buf = ""
 
             elif char == "]":
-                try:
-                    yield QueryStringToken.KEY, int(buf)
-                    buf = ""
-                except ValueError:
-                    yield QueryStringToken.KEY, None
+                if not prev_char.isalpha():
+                    try:
+                        yield QueryStringToken.KEY, int(buf)
+                        buf = ""
+                    except ValueError:
+                        yield QueryStringToken.KEY, None
+                else:
+                    # Actually an object, consume the close bracket
+                    pass
             else:
                 buf = buf + char
-
+            prev_char = char
         if len(buf) > 0:
             yield QueryStringToken.KEY, buf
         else:

--- a/pyquerystring/querystring.py
+++ b/pyquerystring/querystring.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from itertools import izip_longest
-
 from .compat import parse_qsl
 from .compat import is_py3
+from .compat import zip_longest
 
 
 def parse(data):
@@ -139,7 +138,7 @@ class QueryStringParser(object):
         key = key.replace(" ", "")
 
         # Creates iterator of next chars
-        char_groups = izip_longest(key, key[1:], fillvalue=" ")
+        char_groups = zip_longest(key, key[1:], fillvalue=" ")
         prev_char = " "
         for char, next_char in char_groups:
             if char == "[" and not next_char.isalpha():

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,18 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-with open('README.md') as f:
-    readme = f.read()
+readme = """Query String Parsing The Way It Should Be
+
+Python's default urlparse.parse_qs() does not understand the concept of data structures. While this works for simple querystrings, anything more complex returns a less than desirable result.
+
+This library is intended to inteligentally parse complex querystrings that python's library is unable to handle such as the following:
+
+mylist[]=item0&mylist[]=item1
+mylist[0]=item0&mylist[1]=item1
+mylist[0][0]=subitem0&mylist[0][1]=subitem1
+mylist.element=item0
+mylist.element[0]=item0&mylist.element[1]=item0
+"""
 
 with open('LICENSE') as f:
     license = f.read()
@@ -21,8 +31,8 @@ requires = []
 
 setup(
     name='pyquerystring',
-    version='0.4.0',
-    description='Fancy query string parsing & application/x-www-form-urlencoded parsing',
+    version='1.0',
+    description='Query String Parsing The Way It Should Be',
     long_description=readme,
     author='Adam Venturella',
     author_email='aventurella@gmail.com',
@@ -43,9 +53,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.0',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ),
 
 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -66,6 +66,21 @@ class QueryStringSuite(unittest.TestCase):
         self.assertEqual(result["dog"]["name"], "lucy")
         self.assertEqual(result["dog"]["color"], "brown")
 
+    def test_simple_object_3(self):
+        qs = "&id=foo&dog.name=lucy&dog[color]=brown"
+        result = parse(qs)
+
+        self.assertEqual(result["id"], "foo")
+        self.assertEqual(result["dog"]["name"], "lucy")
+        self.assertEqual(result["dog"]["color"], "brown")
+
+    def test_simple_object_4(self):
+        qs = "&id=foo&dog[name]=lucy&dog[ color ]=brown"
+        result = parse(qs)
+        self.assertEqual(result["id"], "foo")
+        self.assertEqual(result["dog"]["name"], "lucy")
+        self.assertEqual(result["dog"]["color"], "brown")
+
     def test_object_with_array(self):
         qs = "&id=foo&dog[0].name=lucy&dog[1].name=radar"
         result = parse(qs)
@@ -78,7 +93,6 @@ class QueryStringSuite(unittest.TestCase):
     def test_push_array(self):
         qs = "&id=foo&dog[]=z-lucy&dog[]=radar"
         result = parse(qs)
-
         self.assertEqual(result["id"], "foo")
         self.assertEqual(len(result["dog"]), 2)
         self.assertEqual(result["dog"][0], "z-lucy")


### PR DESCRIPTION
Hey Adam - 

Added in associative array support to help parse querystrings from the datatables project.  Tried to clean up the docs and bumped the version to 1.0 as the library seems as robust as it can be at this point. 

Stephen
