### PR TITLE
Enhances parser to handle more formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+1.0.1
+-----
+
+Changes:
+ - Enhanced parsing of associative array objects.
+ - Fixes bug where array objects could not end in a digit
+
+
 1.0
 -----
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Fancy query string parsing & application/x-www-form-urlencoded parsing
 
-Copyright 2011-2015 Adam Venturella
+Copyright 2011-2016 Adam Venturella
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pyquerystring/__init__.py
+++ b/pyquerystring/__init__.py
@@ -1,6 +1,6 @@
 # Fancy query string parsing & application/x-www-form-urlencoded parsing
 #
-# Copyright 2011-2015 Adam Venturella
+# Copyright 2011-2016 Adam Venturella
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 __title__ = 'pyquerystring'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __author__ = 'Adam Venturella'
 __license__ = 'Apache 2'
-__copyright__ = 'Copyright 2011-2015 Adam Venturella'
+__copyright__ = 'Copyright 2011-2016 Adam Venturella'
 
 from .querystring import parse
 from .querystring import QueryStringParser

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,13 @@ readme = """Python's default urlparse.parse_qs() does not understand the concept
 This library is intended to inteligentally parse complex querystrings that python's library is unable to handle such as the following:
 
 mylist[]=item0&mylist[]=item1
+
 mylist[0]=item0&mylist[1]=item1
+
 mylist[0][0]=subitem0&mylist[0][1]=subitem1
+
 mylist.element=item0
+
 mylist.element[0]=item0&mylist.element[1]=item0
 """
 

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-readme = """Query String Parsing The Way It Should Be
-
-Python's default urlparse.parse_qs() does not understand the concept of data structures. While this works for simple querystrings, anything more complex returns a less than desirable result.
+readme = """Python's default urlparse.parse_qs() does not understand the concept of data structures. While this works for simple querystrings, anything more complex returns a less than desirable result.
 
 This library is intended to inteligentally parse complex querystrings that python's library is unable to handle such as the following:
 
@@ -31,7 +29,7 @@ requires = []
 
 setup(
     name='pyquerystring',
-    version='1.0',
+    version='1.0.1',
     description='Query String Parsing The Way It Should Be',
     long_description=readme,
     author='Adam Venturella',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,6 +42,11 @@ class QueryStringSuite(unittest.TestCase):
         self.assertEqual(result["dog"][0], "tucker")
         self.assertEqual(result["dog"][1], "lucy")
 
+    def test_bad_format(self):
+        qs = "&id=foo&dog[1]]=lucy"
+        with self.assertRaises(IOError):
+            parse(qs)
+
     def test_simple_array(self):
         qs = "&id=foo&dog[1]=lucy&dog[0]=tucker"
         result = parse(qs)
@@ -75,11 +80,20 @@ class QueryStringSuite(unittest.TestCase):
         self.assertEqual(result["dog"]["color"], "brown")
 
     def test_simple_object_4(self):
-        qs = "&id=foo&dog[name]=lucy&dog[ color ]=brown"
+        qs = "&id=foo&dog2[name]=lucy&dog2[name2]=lucy&dog[ color ]=brown"
         result = parse(qs)
+
         self.assertEqual(result["id"], "foo")
-        self.assertEqual(result["dog"]["name"], "lucy")
+        self.assertEqual(result["dog2"]["name2"], "lucy")
         self.assertEqual(result["dog"]["color"], "brown")
+
+    def test_odd_names(self):
+        qs = "&id=foo&dog[name.1]=lucy&dog[name[2]]=radar"
+        result = parse(qs)
+
+        self.assertEqual(result["id"], "foo")
+        self.assertEqual(result["dog"]["name.1"], "lucy")
+        self.assertEqual(result["dog"]["name[2]"], "radar")
 
     def test_object_with_array(self):
         qs = "&id=foo&dog[0].name=lucy&dog[1].name=radar"


### PR DESCRIPTION
Hey Adam-

One more round to better handle associative arrays.  
Fixes use of: dog[name1] dog[name.1] and dog[name[2]]

Bumped to version 1.0.1.
